### PR TITLE
add patch for add-rbd-mirror-dest-in-qemuDomainBlockRebase

### DIFF
--- a/SOURCES/libvirt-qemu-add-rbd-mirror-dest-in-qemuDomainBlockRebase.patch
+++ b/SOURCES/libvirt-qemu-add-rbd-mirror-dest-in-qemuDomainBlockRebase.patch
@@ -1,0 +1,138 @@
+From 7c834ad2d384035e93dda5aa47bbc5059f7f508c Mon Sep 17 00:00:00 2001
+From: Shengjing Zhu <zhsj@umcloud.com>
+Date: Fri, 17 Mar 2017 17:46:52 +0800
+Subject: [PATCH] add rbd mirror dest in qemuDomainBlockRebase
+
+* backport upstream patch "BlockCopy support rbd external destination
+file"
+* Detect rbd source in qemuDomainBlockCopyCommon
+
+Signed-off-by: Shengjing Zhu <zhsj@umcloud.com>
+---
+ src/qemu/qemu_driver.c | 94 +++++++++++++++++++++++++++++++-------------------
+ 1 file changed, 59 insertions(+), 35 deletions(-)
+
+diff --git a/src/qemu/qemu_driver.c b/src/qemu/qemu_driver.c
+index 7a04e6720..c42d7a308 100644
+--- a/src/qemu/qemu_driver.c
++++ b/src/qemu/qemu_driver.c
+@@ -16623,6 +16623,13 @@ qemuDomainBlockCopyCommon(virDomainObjPtr vm,
+     bool need_unlink = false;
+     virQEMUDriverConfigPtr cfg = NULL;
+     const char *format = NULL;
++
++    if (STRPREFIX(mirror->path, "rbd:")) {
++        mirror->format = VIR_STORAGE_FILE_RAW;
++        mirror->protocol = VIR_STORAGE_NET_PROTOCOL_RBD;
++        mirror->type = VIR_STORAGE_TYPE_NETWORK;
++    }
++
+     int desttype = virStorageSourceGetActualType(mirror);
+ 
+     /* Preliminaries: find the disk we are editing, sanity checks */
+@@ -16685,50 +16692,67 @@ qemuDomainBlockCopyCommon(virDomainObjPtr vm,
+ 
+     /* Prepare the destination file.  */
+     /* XXX Allow non-file mirror destinations */
+-    if (!virStorageSourceIsLocalStorage(mirror)) {
++    if (!virStorageSourceIsLocalStorage(mirror) &&
++            (mirror->type != VIR_STORAGE_TYPE_NETWORK ||
++             mirror->protocol != VIR_STORAGE_NET_PROTOCOL_RBD)) {
+         virReportError(VIR_ERR_ARGUMENT_UNSUPPORTED, "%s",
+                        _("non-file destination not supported yet"));
+         goto endjob;
+     }
+-    if (stat(mirror->path, &st) < 0) {
+-        if (errno != ENOENT) {
+-            virReportSystemError(errno, _("unable to stat for disk %s: %s"),
+-                                 disk->dst, mirror->path);
+-            goto endjob;
+-        } else if (flags & VIR_DOMAIN_BLOCK_COPY_REUSE_EXT ||
+-                   desttype == VIR_STORAGE_TYPE_BLOCK) {
+-            virReportSystemError(errno,
+-                                 _("missing destination file for disk %s: %s"),
+-                                 disk->dst, mirror->path);
+-            goto endjob;
+-        }
+-    } else if (!S_ISBLK(st.st_mode)) {
+-        if (st.st_size && !(flags & VIR_DOMAIN_BLOCK_COPY_REUSE_EXT)) {
+-            virReportError(VIR_ERR_CONFIG_UNSUPPORTED,
+-                           _("external destination file for disk %s already "
+-                             "exists and is not a block device: %s"),
+-                           disk->dst, mirror->path);
+-            goto endjob;
+-        }
+-        if (desttype == VIR_STORAGE_TYPE_BLOCK) {
+-            virReportError(VIR_ERR_INVALID_ARG,
+-                           _("blockdev flag requested for disk %s, but file "
+-                             "'%s' is not a block device"),
+-                           disk->dst, mirror->path);
+-            goto endjob;
++    if (virStorageSourceIsLocalStorage(mirror)) {
++        if (stat(mirror->path, &st) < 0) {
++            if (errno != ENOENT) {
++                virReportSystemError(errno, _("unable to stat for disk %s: %s"),
++                                     disk->dst, mirror->path);
++                goto endjob;
++            } else if (flags & VIR_DOMAIN_BLOCK_COPY_REUSE_EXT ||
++                       desttype == VIR_STORAGE_TYPE_BLOCK) {
++                virReportSystemError(errno,
++                                     _("missing destination file for disk %s: %s"),
++                                     disk->dst, mirror->path);
++                goto endjob;
++            }
++        } else if (!S_ISBLK(st.st_mode)) {
++            if (st.st_size && !(flags & VIR_DOMAIN_BLOCK_COPY_REUSE_EXT)) {
++                virReportError(VIR_ERR_CONFIG_UNSUPPORTED,
++                               _("external destination file for disk %s already "
++                                 "exists and is not a block device: %s"),
++                               disk->dst, mirror->path);
++                goto endjob;
++            }
++            if (desttype == VIR_STORAGE_TYPE_BLOCK) {
++                virReportError(VIR_ERR_INVALID_ARG,
++                               _("blockdev flag requested for disk %s, but file "
++                                 "'%s' is not a block device"),
++                               disk->dst, mirror->path);
++                goto endjob;
++            }
+         }
++    } else if (!(flags & VIR_DOMAIN_BLOCK_COPY_REUSE_EXT)) {
++        virReportError(VIR_ERR_INVALID_ARG,
++                       "%s",
++                       _("only external destination file is supported for "
++                         "rbd protocol"));
++        goto endjob;
+     }
+ 
+     if (!mirror->format) {
+-        if (!(flags & VIR_DOMAIN_BLOCK_COPY_REUSE_EXT)) {
+-            mirror->format = disk->src->format;
++        if (virStorageSourceIsLocalStorage(mirror)) {
++            if (!(flags & VIR_DOMAIN_BLOCK_COPY_REUSE_EXT)) {
++                mirror->format = disk->src->format;
++            } else {
++                /* If the user passed the REUSE_EXT flag, then either they
++                 * can also pass the RAW flag or use XML to tell us the format.
++                 * So if we get here, we assume it is safe for us to probe the
++                 * format from the file that we will be using.  */
++                mirror->format = virStorageFileProbeFormat(mirror->path, cfg->user,
++                                                           cfg->group);
++            }
+         } else {
+-            /* If the user passed the REUSE_EXT flag, then either they
+-             * can also pass the RAW flag or use XML to tell us the format.
+-             * So if we get here, we assume it is safe for us to probe the
+-             * format from the file that we will be using.  */
+-            mirror->format = virStorageFileProbeFormat(mirror->path, cfg->user,
+-                                                       cfg->group);
++            virReportError(VIR_ERR_INVALID_ARG,
++                           _("format is required for %s"),
++                           mirror->path);
++            goto endjob;
+         }
+     }
+ 
+-- 
+2.11.0
+

--- a/SPECS/libvirt.spec
+++ b/SPECS/libvirt.spec
@@ -382,7 +382,7 @@
 Summary: Library providing a simple virtualization API
 Name: libvirt
 Version: 1.2.17
-Release: 13%{?dist}.5.1%{?extra_release}
+Release: 13%{?dist}.5.2%{?extra_release}
 License: LGPLv2+
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
@@ -663,6 +663,7 @@ Patch267: libvirt-qemu-driver-Separate-bulk-stats-worker-for-block-devices.patch
 Patch268: libvirt-qemu-bulk-stats-Don-t-access-possibly-blocked-storage.patch
 
 Patch10000: libvirt-qemu-agent-Fix-QEMU-guest-agent-is-not-available-due-to-an-error.patch
+Patch10001: libvirt-qemu-add-rbd-mirror-dest-in-qemuDomainBlockRebase.patch
 
 %if %{with_libvirtd}
 Requires: libvirt-daemon = %{version}-%{release}
@@ -2613,6 +2614,9 @@ exit 0
 %doc examples/systemtap
 
 %changelog
+* Mon Mar 27 2017 Shengjing Zhu <zhsj@umcloud.com> - 1.2.17-13.el7_2.5.2
+- qemu: Add add rbd mirror dest in qemuDomainBlockRebase
+
 * Mon Aug 29 2016 Yaowei Bai <baiyaowei@cmss.chinamobile.com> - 1.2.17-13.el7_2.5.1
 - libvirt-qemu-agent-Fix-QEMU-guest-agent-is-not-available-due-to-an-error.patch
 


### PR DESCRIPTION
这次更新的版本，比原来的更改更简单，只修改了 qemuDomainBlockCopyCommon 这个函数。
commit 在 https://github.com/zhsj/libvirt/commit/7c834ad2d384035e93dda5aa47bbc5059f7f508c 可更方便 review。

另外，libvirt 本身似乎没有对 qemuDomainBlock 这类函数的测试，前面说的用 avocado 测试，是否有例子？